### PR TITLE
Adds boolean config value support

### DIFF
--- a/engine/dlib/sdk_gen.json
+++ b/engine/dlib/sdk_gen.json
@@ -16,13 +16,15 @@
 					"FConfigFileDestroy",
 					"FConfigFileGetString",
 					"FConfigFileGetInt",
-					"FConfigFileGetFloat"
+					"FConfigFileGetFloat",
+					"FConfigFileGetBoolean"
 				],
 				"rename": {
 					"HConfigFile": "HConfig",
 					"ConfigFileGetString": "GetString",
 					"ConfigFileGetInt": "GetInt",
-					"ConfigFileGetFloat": "GetFloat"
+					"ConfigFileGetFloat": "GetFloat",
+					"ConfigFileGetBoolean": "GetBoolean"
 				}
 			},
 			"csharp": {
@@ -35,13 +37,15 @@
 					"FConfigFileDestroy",
 					"FConfigFileGetString",
 					"FConfigFileGetInt",
-					"FConfigFileGetFloat"
+					"FConfigFileGetFloat",
+					"FConfigFileGetBoolean"
 				],
 				"rename": {
 					"HConfigFile": "Config*",
 					"ConfigFileGetString": "GetString",
 					"ConfigFileGetInt": "GetInt",
 					"ConfigFileGetFloat": "GetFloat",
+					"ConfigFileGetBoolean": "GetBoolean",
 					"ConfigFile": "Config"
 				}
 			}

--- a/engine/dlib/src/dlib/configfile.cpp
+++ b/engine/dlib/src/dlib/configfile.cpp
@@ -54,6 +54,7 @@ struct ConfigFilePluginDesc
     FConfigFileGetString m_GetString;
     FConfigFileGetInt m_GetInt;
     FConfigFileGetFloat m_GetFloat;
+    FConfigFileGetBoolean m_GetBoolean;
 
     const ConfigFilePluginDesc* m_Next;
 };
@@ -72,7 +73,8 @@ void ConfigFileRegisterExtension(void* _desc,
     FConfigFileDestroy destroy,
     FConfigFileGetString get_string,
     FConfigFileGetInt get_int,
-    FConfigFileGetFloat get_float)
+    FConfigFileGetFloat get_float,
+    FConfigFileGetBoolean get_boolean)
 {
     struct ConfigFilePluginDesc* desc = (struct ConfigFilePluginDesc*)_desc;
     DM_STATIC_ASSERT(ConfigFileExtensionDescBufferSize >= sizeof(struct ConfigFilePluginDesc), Invalid_Struct_Size);
@@ -82,6 +84,7 @@ void ConfigFileRegisterExtension(void* _desc,
     desc->m_GetString = get_string;
     desc->m_GetInt = get_int;
     desc->m_GetFloat = get_float;
+    desc->m_GetBoolean = get_boolean;
 
     desc->m_Next = g_FirstExtension;
     g_FirstExtension = desc;
@@ -171,6 +174,31 @@ static bool GetFloatOverride(HConfigFile config, const char* key, float default_
     return false;
 }
 
+static float GetBaseBoolean(HConfigFile config, const char* key, bool default_value)
+{
+    const char* tmp = GetBaseString(config, key, 0);
+    if (tmp == 0)
+        return default_value;
+    if (strcmp(tmp, "true") == 0 || strcmp(tmp, "1") == 0)
+        return true;
+    if (strcmp(tmp, "false") == 0 || strcmp(tmp, "0") == 0 || strcmp(tmp, "no") == 0)
+        return false;
+    dmLogWarning("Unable to convert '%s' to boolean", tmp);
+    return default_value;
+}
+
+static bool GetBooleanOverride(HConfigFile config, const char* key, bool default_value, bool* out_value)
+{
+    const ConfigFilePluginDesc* plugin = GetFirstExtension();
+    while (plugin != 0)
+    {
+        if (plugin->m_GetBoolean && plugin->m_GetBoolean(config, key, default_value, out_value))
+            return true;
+        plugin = plugin->m_Next;
+    }
+    return false;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // C api
 
@@ -197,6 +225,15 @@ float ConfigFileGetFloat(HConfigFile config, const char* key, float default_valu
     float base_value = GetBaseFloat(config, key, default_value);
     float out_value = 0;
     if (GetFloatOverride(config, key, base_value, &out_value))
+        return out_value;
+    return base_value;
+}
+
+bool ConfigFileGetBoolean(HConfigFile config, const char* key, bool default_value)
+{
+    bool base_value = GetBaseBoolean(config, key, default_value);
+    bool out_value = false;
+    if (GetBooleanOverride(config, key, base_value, &out_value))
         return out_value;
     return base_value;
 }
@@ -803,5 +840,10 @@ namespace dmConfigFile
     float GetFloat(HConfig config, const char* key, float default_value)
     {
         return ConfigFileGetFloat(config, key, default_value);
+    }
+
+    bool GetBoolean(HConfig config, const char* key, bool default_value)
+    {
+        return ConfigFileGetBoolean(config, key, default_value);
     }
 }

--- a/engine/dlib/src/dmsdk/dlib/configfile.h
+++ b/engine/dlib/src/dmsdk/dlib/configfile.h
@@ -116,7 +116,7 @@ int32_t ConfigFileGetInt(HConfigFile config, const char* key, int32_t default_va
  *     float gravity = ConfigFileGetFloat(params->m_ConfigFile, "physics.gravity_y", -9.8f);
  * }
  * ```
-* @examples
+ * @examples
  *
  * ```cpp
  * static dmExtension::Result AppInitialize(dmExtension::AppParams* params)
@@ -127,6 +127,35 @@ int32_t ConfigFileGetInt(HConfigFile config, const char* key, int32_t default_va
  *
  */
 float ConfigFileGetFloat(HConfigFile config, const char* key, float default_value);
+
+/*# get config value as boolean
+ *
+ * Get config value as boolean, returns default if the key isn't found
+ *
+ * @name ConfigFileGetBoolean
+ * @param config [type:HConfigFile] Config file handle
+ * @param key [type:const char*] Key in format section.key (.key for no section)
+ * @param default_value [type:bool] Default value to return if key isn't found
+ * @return value [type:bool] found value or default value
+ *
+ * @examples
+ * ```c
+ * static ExtensionResult AppInitialize(ExtensionAppParams* params)
+ * {
+ *     bool vsync = ConfigFileGetBoolean(params->m_ConfigFile, "display.vsync", false);
+ * }
+ * ```
+ * @examples
+ *
+ * ```cpp
+ * static dmExtension::Result AppInitialize(dmExtension::AppParams* params)
+ * {
+ *     bool vsync = dmConfigFile::GetBoolean(params->m_ConfigFile, "display.vsync", false);
+ * }
+ * ```
+ *
+ */
+bool ConfigFileGetBoolean(HConfigFile config, const char* key, bool default_value);
 
 // Extensions
 
@@ -176,6 +205,17 @@ typedef bool (*FConfigFileGetInt)(HConfigFile config, const char* key, int32_t d
  * @return result [type:bool] True if property was found
  */
 typedef bool (*FConfigFileGetFloat)(HConfigFile config, const char* key, float default_value, float* out);
+
+/*# Called when a boolean is requested from the config file extension
+ * @typedef
+ * @name FConfigFileGetBoolean
+ * @param config [type:HConfigFile] Config file handle
+ * @param key [type:const char*] Key in format section.key (.key for no section)
+ * @param default_value [type:bool] Default value to return if key isn't found
+ * @param out [type:bool*] Out argument where result is stored if found.
+ * @return result [type:bool] True if property was found
+ */
+typedef bool (*FConfigFileGetBoolean)(HConfigFile config, const char* key, bool default_value, bool* out);
 
 /*# Used when registering new config file extensions.
  * It defines the minimum size of the description blob being registered.

--- a/engine/dlib/src/dmsdk/dlib/configfile_gen.hpp
+++ b/engine/dlib/src/dmsdk/dlib/configfile_gen.hpp
@@ -1,5 +1,5 @@
 // Generated, do not edit!
-// Generated with cwd=/Users/bjornritzl/projects/defold/engine/dlib and cmd=/Users/bjornritzl/projects/defold/scripts/dmsdk/gen_sdk.py -i /Users/bjornritzl/projects/defold/engine/dlib/sdk_gen.json
+// Generated with cwd=/home/paul/Documents/Projects/defold/engine/dlib and cmd=/home/paul/Documents/Projects/defold/scripts/dmsdk/gen_sdk.py -i /home/paul/Documents/Projects/defold/engine/dlib/sdk_gen.json
 
 // Copyright 2020-2025 The Defold Foundation
 // Copyright 2014-2020 King
@@ -32,6 +32,7 @@
  * @language C++
  * @name ConfigFile
  * @namespace dmConfigFile
+ * @path engine/dlib/src/dmsdk/dlib/configfile_gen.hpp
  */
 
 #include <stdint.h>
@@ -124,6 +125,31 @@ namespace dmConfigFile
      */
     float GetFloat(HConfig config, const char * key, float default_value);
 
+    /*# get config value as boolean
+     * Get config value as boolean, returns default if the key isn't found
+     * @name GetBoolean
+     * @language C++
+     * @param config [type:HConfigFile] Config file handle
+     * @param key [type:const char*] Key in format section.key (.key for no section)
+     * @param default_value [type:bool] Default value to return if key isn't found
+     * @return value [type:bool] found value or default value
+     * @examples 
+     * ```c
+     * static ExtensionResult AppInitialize(ExtensionAppParams* params)
+     * {
+     *     bool vsync = ConfigFileGetBoolean(params->m_ConfigFile, "display.vsync", false);
+     * }
+     * ```
+     * @examples 
+     * ```cpp
+     * static dmExtension::Result AppInitialize(dmExtension::AppParams* params)
+     * {
+     *     bool vsync = dmConfigFile::GetBoolean(params->m_ConfigFile, "display.vsync", false);
+     * }
+     * ```
+     */
+    bool GetBoolean(HConfig config, const char * key, bool default_value);
+
 
 } // namespace dmConfigFile
 
@@ -208,6 +234,30 @@ namespace dmConfigFile
  * ```
  */
 
+/*# get config value as boolean
+ * Get config value as boolean, returns default if the key isn't found
+ * @name ConfigFileGetBoolean
+ * @language C
+ * @param config [type:HConfigFile] Config file handle
+ * @param key [type:const char*] Key in format section.key (.key for no section)
+ * @param default_value [type:bool] Default value to return if key isn't found
+ * @return value [type:bool] found value or default value
+ * @examples 
+ * ```c
+ * static ExtensionResult AppInitialize(ExtensionAppParams* params)
+ * {
+ *     bool vsync = ConfigFileGetBoolean(params->m_ConfigFile, "display.vsync", false);
+ * }
+ * ```
+ * @examples 
+ * ```cpp
+ * static dmExtension::Result AppInitialize(dmExtension::AppParams* params)
+ * {
+ *     bool vsync = dmConfigFile::GetBoolean(params->m_ConfigFile, "display.vsync", false);
+ * }
+ * ```
+ */
+
 /*# Called when config file extension is created
  * Called when config file extension is created
  * @typedef
@@ -260,8 +310,21 @@ namespace dmConfigFile
  * @return result [type:bool] True if property was found
  */
 
+/*# Called when a boolean is requested from the config file extension
+ * Called when a boolean is requested from the config file extension
+ * @typedef
+ * @name FConfigFileGetBoolean
+ * @language C
+ * @param config [type:HConfigFile] Config file handle
+ * @param key [type:const char*] Key in format section.key (.key for no section)
+ * @param default_value [type:bool] Default value to return if key isn't found
+ * @param out [type:bool*] Out argument where result is stored if found.
+ * @return result [type:bool] True if property was found
+ */
+
 /*# Used when registering new config file extensions.
  * It defines the minimum size of the description blob being registered.
+ * @constant
  * @name ConfigFileExtensionDescBufferSize
  * @language C
  */

--- a/engine/dlib/src/test/data/test.config
+++ b/engine/dlib/src/test/data/test.config
@@ -19,3 +19,4 @@ bad_int2 = 123x
 string = hello
 int = 42
 float = 1.0
+boolean = true

--- a/engine/dlib/src/test/test_configfile.cpp
+++ b/engine/dlib/src/test/test_configfile.cpp
@@ -411,12 +411,15 @@ TEST_P(ConfigfileExtension, ConfigfileExtension)
     ASSERT_STREQ("world", dmConfigFile::GetString(config, "ext.string", 0));
     ASSERT_STREQ("42", dmConfigFile::GetString(config, "ext.int", 0));
     ASSERT_STREQ("1.0", dmConfigFile::GetString(config, "ext.float", 0));
+    ASSERT_STREQ("false", dmConfigFile::GetString(config, "ext.boolean", 0));
 
     ASSERT_EQ(84, dmConfigFile::GetInt(config, "ext.int", 0));
     ASSERT_EQ(2.0f, dmConfigFile::GetFloat(config, "ext.float", 0));
+    ASSERT_EQ(true, dmConfigFile::GetBoolean(config, "ext.boolean", false));
 
     ASSERT_EQ(1301, dmConfigFile::GetInt(config, "ext.virtual", 0));
     ASSERT_EQ(4096.0f, dmConfigFile::GetFloat(config, "ext.virtual", 0));
+    ASSERT_EQ(true, dmConfigFile::GetBoolean(config, "ext.virtual", false));
 }
 
 const TestParam params_extension[] = {


### PR DESCRIPTION
### **User description**
Adds support for reading boolean values from config files.


This includes:
- Adding `ConfigFileGetBoolean` to the C and C++ APIs.
- Adding support for boolean values in config file extensions.
- Adding test coverage for the new functionality.

## PR checklist

* [ ] Code
	* [ ] Add engine and/or editor unit tests.
	* [ ] New and changed code follows the overall code style of existing code
	* [ ] Add comments where needed
* [ ] Documentation
	* [ ] Make sure that API documentation is updated in code comments
	* [ ] Make sure that manuals are updated (in github.com/defold/doc)
* [ ] Prepare pull request and affected issue for automatic release notes generator
	* [ ] Pull request - Write a message that explains what this pull request does. What was the problem? How was it solved? What are the changes to APIs or the new APIs introduced? This message will be used in the generated release notes. Make sure it is well written and understandable for a user of Defold.
	* [ ] Pull request - Write a pull request title that in a sentence summarises what the pull request does. Do not include "Issue-1234 ..." in the title. This text will be used in the generated release notes.
	* [ ] Pull request - Link the pull request to the issue(s) it is closing. Use on of the [approved closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
	* [ ] Affected issue - Assign the issue to a project. Do not assign the pull request to a project if there is an issue which the pull request closes.
	* [ ] Affected issue - Assign the "breaking change" label to the issue if introducing a breaking change.
	* [ ] Affected issue - Assign the "skip release notes" is the issue should not be included in the generated release notes.

----------

Example of a well written PR description:

1. Start with the user facing changes. This will end up in the release notes.
1. Add one of the GitHub approved closing keywords
1. Optionally also add the technical changes made. This is information that might help the reviewer. It will not show up in the release notes. Technical changes are identified by a line starting with one of these:
   1. `### Technical changes` 
   1. `Technical changes:`
   2. `Technical notes:`

```
There was a anomaly in the carbon chroniton propeller, introduced in version 8.10.2. This fix will make sure to reset the phaser collector on application startup.

Fixes #1234

### Technical changes
* Pay special attention to line 23 of phaser_collector.clj as it contains some interesting optimizations
* The propeller code was not taking into account a negative phase.
```


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ConfigFileGetBoolean` function to C and C++ APIs

- Support boolean value parsing from config files

- Add extension support for boolean config values

- Include comprehensive test coverage for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config File"] --> B["ConfigFileGetBoolean API"]
  B --> C["Boolean Parser"]
  C --> D["Extension Support"]
  D --> E["Test Coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configfile.cpp</strong><dd><code>Core boolean config value implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/dlib/src/dlib/configfile.cpp

<ul><li>Add <code>FConfigFileGetBoolean</code> to plugin descriptor structure<br> <li> Implement <code>GetBaseBoolean</code> function for parsing boolean strings<br> <li> Add <code>ConfigFileGetBoolean</code> C API function with extension override <br>support<br> <li> Add <code>GetBoolean</code> C++ wrapper function</ul>


</details>


  </td>
  <td><a href="https://github.com/appsoluut/defold/pull/1/files#diff-19adbec959c90c39301b89616ceeae77c100489f46dd1470fd326df904d4376a">+43/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configfile.h</strong><dd><code>C API header with boolean function declarations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/dlib/src/dmsdk/dlib/configfile.h

<ul><li>Add <code>ConfigFileGetBoolean</code> function declaration with documentation<br> <li> Add <code>FConfigFileGetBoolean</code> typedef for extension callbacks<br> <li> Fix formatting in existing documentation examples</ul>


</details>


  </td>
  <td><a href="https://github.com/appsoluut/defold/pull/1/files#diff-42e7a9702109627377d1da86400ae9b1908da91ab5042ec7d3a9f35771a22260">+41/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configfile_gen.hpp</strong><dd><code>Generated API documentation for boolean support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/dlib/src/dmsdk/dlib/configfile_gen.hpp

<ul><li>Add <code>GetBoolean</code> function to C++ namespace with documentation<br> <li> Add <code>ConfigFileGetBoolean</code> C function documentation<br> <li> Add <code>FConfigFileGetBoolean</code> typedef for extension callbacks</ul>


</details>


  </td>
  <td><a href="https://github.com/appsoluut/defold/pull/1/files#diff-2c31246b148b565984169241a69a44e857fd2b5945c1ba9cc16d72f6e11cbc0e">+64/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_configfile.cpp</strong><dd><code>Test coverage for boolean config functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/dlib/src/test/test_configfile.cpp

<ul><li>Add test assertions for boolean config value retrieval<br> <li> Test both direct boolean values and virtual boolean values<br> <li> Verify extension support for boolean values</ul>


</details>


  </td>
  <td><a href="https://github.com/appsoluut/defold/pull/1/files#diff-d23a851f0e66b084706797549050c91fcc6d8283ecb7f3c96987d3512bccb1a2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.config</strong><dd><code>Test data with boolean config value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/dlib/src/test/data/test.config

- Add `boolean = true` test entry to `[ext]` section


</details>


  </td>
  <td><a href="https://github.com/appsoluut/defold/pull/1/files#diff-f118cbb76a22217fc898d030135dbc98d42c469b25fbd2676cb5b1aee84d2cc2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sdk_gen.json</strong><dd><code>SDK generation configuration for boolean support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engine/dlib/sdk_gen.json

<ul><li>Add <code>FConfigFileGetBoolean</code> to ignore lists for C++ and C# bindings<br> <li> Add <code>ConfigFileGetBoolean</code> to <code>GetBoolean</code> rename mappings</ul>


</details>


  </td>
  <td><a href="https://github.com/appsoluut/defold/pull/1/files#diff-3fc2d47e160c3a554bfced1764b1776d376b1d2bf5d631f176efd8acb1ae3b7b">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

